### PR TITLE
Shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /config.status
 /configure
 /libmash.a
+/libmash.so
+/libmash.dylib
 /mash

--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ ifeq ($(UNAME_S),Darwin)
 	DYNAMICFLAGS += $(CXXFLAGS) -dynamiclib
 	DYNAMICNAME = libmash.dylib 
 else
-	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy -shared
+	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy
 	CXXDYNAMICFLAGS += $(CXXFLAGS) -shared
 	DYNAMICNAME = libmash.so 
 	CFLAGS += -include src/mash/memcpyLink.h
@@ -36,7 +36,7 @@ SOURCES=\
 
 OBJECTS=$(SOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
 
-all : mash libmash.a libmash.so
+all : mash libmash.a dynamic_libmash
 
 mash : libmash.a src/mash/memcpyWrap.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o mash src/mash/memcpyWrap.o libmash.a @capnp@/lib/libcapnp.a @capnp@/lib/libkj.a @mathlib@ -lstdc++ -lz -lm -lpthread
@@ -45,7 +45,7 @@ libmash.a : $(OBJECTS)
 	ar -cr libmash.a $(OBJECTS)
 	ranlib libmash.a
 
-libmash.so : $(OBJECTS)
+dynamic_libmash : $(OBJECTS)
 	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -Wl -o $(DYNAMICNAME) $(OBJECTS) @capnp@/lib/libkj.a @capnp@/lib/libcapnp.a src/mash/memcpyWrap.o @mathlib@ -lstdc++ -lz -lm -lpthread
 
 .SUFFIXES :

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,12 +1,16 @@
-CXXFLAGS += -O3 -std=c++11 -Isrc -I@capnp@/include -I @mathinc@
+CXXFLAGS += -O3 -std=c++11 -fPIC -Isrc -I@capnp@/include -I @mathinc@
 CPPFLAGS += @amcppflags@
 
 UNAME_S=$(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 	CXXFLAGS += -mmacosx-version-min=10.7 -stdlib=libc++
+	DYNAMICFLAGS += $(CXXFLAGS) -dynamiclib
+	DYNAMICNAME = libmash.dylib 
 else
-	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy
+	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy -shared
+	CXXDYNAMICFLAGS += $(CXXFLAGS) -shared
+	DYNAMICNAME = libmash.so 
 	CFLAGS += -include src/mash/memcpyLink.h
 endif
 
@@ -32,7 +36,7 @@ SOURCES=\
 
 OBJECTS=$(SOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
 
-all : mash libmash.a
+all : mash libmash.a libmash.so
 
 mash : libmash.a src/mash/memcpyWrap.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o mash src/mash/memcpyWrap.o libmash.a @capnp@/lib/libcapnp.a @capnp@/lib/libkj.a @mathlib@ -lstdc++ -lz -lm -lpthread
@@ -40,6 +44,9 @@ mash : libmash.a src/mash/memcpyWrap.o
 libmash.a : $(OBJECTS)
 	ar -cr libmash.a $(OBJECTS)
 	ranlib libmash.a
+
+libmash.so : $(OBJECTS)
+	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -Wl -o $(DYNAMICNAME) $(OBJECTS) @capnp@/lib/libkj.a @capnp@/lib/libcapnp.a src/mash/memcpyWrap.o @mathlib@ -lstdc++ -lz -lm -lpthread
 
 .SUFFIXES :
 
@@ -63,12 +70,14 @@ install : mash
 	mkdir -p @prefix@/include/mash/capnp
 	cp `pwd`/mash @prefix@/bin/
 	cp `pwd`/libmash.a @prefix@/lib/
+	cp `pwd`/${DYNAMICNAME} @prefix@/lib/
 	cp `pwd`/src/mash/*.h @prefix@/include/mash/
 	cp `pwd`/src/mash/capnp/MinHash.capnp.h @prefix@/include/mash/capnp/
 
 clean :
 	-rm mash
 	-rm libmash.a
+	-rm libmash.so
 	-rm src/mash/*.o
 	-rm src/mash/capnp/*.o
 	-rm src/mash/capnp/*.c++


### PR DESCRIPTION
 Makefile.in modified:

A **dynamic library** (libmash.so on Linux and libmash.dylib on MacOS) is now created during the `make` phase. They will be installed in the correct directory when `make install`.

