### PR TITLE
Capi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,18 +1,20 @@
 CXXFLAGS += -O3 -std=c++11 -Isrc -I@capnp@/include -I @mathinc@
 CPPFLAGS += @amcppflags@
 
+CXXDYNAMICFLAGS = -fPIC -O3 -std=c++11 -Isrc
+
 UNAME_S=$(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 	CXXFLAGS += -mmacosx-version-min=10.7 -stdlib=libc++
 	
-	CXXDYNAMICFLAGS +=  -O3 -std=c++11 -Isrc -dynamiclib
+	CXXDYNAMICFLAGS += -dynamiclib
 	DYNAMICNAME = libmash.dylib 
 else
 	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy
 	CFLAGS += -include src/mash/memcpyLink.h
 
-	CXXDYNAMICFLAGS +=  -O3 -std=c++11 -Isrc -shared 
+	CXXDYNAMICFLAGS +=  -shared 
 	DYNAMICNAME = libmash.so
 endif
 
@@ -41,7 +43,7 @@ OBJECTS=$(SOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
 CSOURCES=\
 	src/capi/HashList.cpp \
 
-COBJECTS=$(CSOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
+COBJECTS=$(CSOURCES:.cpp=.o)
 
 all : mash libmash.a dynamic_libmash
 
@@ -52,8 +54,8 @@ libmash.a : $(OBJECTS)
 	ar -cr libmash.a $(OBJECTS)
 	ranlib libmash.a
 
-dynamic_libmash : $(COBJECTS)
-	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -o $(DYNAMICNAME) $(COBJECTS) -lstdc++ -lz -lm -lpthread
+dynamic_libmash : $(OBJECTS) $(COBJECTS)
+	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -o $(DYNAMICNAME) $(OBJECTS) $(COBJECTS) @capnp@/lib/libcapnp.a @capnp@/lib/libkj.a @mathlib@ -lstdc++ -lz -lm -lpthread
 
 .SUFFIXES :
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,17 +1,19 @@
-CXXFLAGS += -O3 -std=c++11 -fPIC -Isrc -I@capnp@/include -I @mathinc@
+CXXFLAGS += -O3 -std=c++11 -Isrc -I@capnp@/include -I @mathinc@
 CPPFLAGS += @amcppflags@
 
 UNAME_S=$(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 	CXXFLAGS += -mmacosx-version-min=10.7 -stdlib=libc++
-	DYNAMICFLAGS += $(CXXFLAGS) -dynamiclib
+	
+	CXXDYNAMICFLAGS +=  -O3 -std=c++11 -Isrc -dynamiclib
 	DYNAMICNAME = libmash.dylib 
 else
 	CXXFLAGS += -include src/mash/memcpyLink.h -Wl,--wrap=memcpy
-	CXXDYNAMICFLAGS += $(CXXFLAGS) -shared
-	DYNAMICNAME = libmash.so 
 	CFLAGS += -include src/mash/memcpyLink.h
+
+	CXXDYNAMICFLAGS +=  -O3 -std=c++11 -Isrc -shared 
+	DYNAMICNAME = libmash.so
 endif
 
 SOURCES=\
@@ -36,6 +38,11 @@ SOURCES=\
 
 OBJECTS=$(SOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
 
+CSOURCES=\
+	src/capi/HashList.cpp \
+
+COBJECTS=$(CSOURCES:.cpp=.o) src/mash/capnp/MinHash.capnp.o
+
 all : mash libmash.a dynamic_libmash
 
 mash : libmash.a src/mash/memcpyWrap.o
@@ -45,8 +52,8 @@ libmash.a : $(OBJECTS)
 	ar -cr libmash.a $(OBJECTS)
 	ranlib libmash.a
 
-dynamic_libmash : $(OBJECTS)
-	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -Wl -o $(DYNAMICNAME) $(OBJECTS) @capnp@/lib/libkj.a @capnp@/lib/libcapnp.a src/mash/memcpyWrap.o @mathlib@ -lstdc++ -lz -lm -lpthread
+dynamic_libmash : $(COBJECTS)
+	$(CXX) $(CXXDYNAMICFLAGS) $(CPPFLAGS) -o $(DYNAMICNAME) $(COBJECTS) -lstdc++ -lz -lm -lpthread
 
 .SUFFIXES :
 

--- a/src/capi/HashList.cpp
+++ b/src/capi/HashList.cpp
@@ -1,0 +1,22 @@
+
+#include "base.h"
+#include "HashList.h"
+
+extern "C" {
+
+MASH_EXTERN_API int mash_create_hash_list(HashList* hlptr, int kmerSize) {
+    
+    hlptr = new HashList(kmerSize);
+    return 0;
+
+}
+
+MASH_EXTERN_API int mash_hash_list_size(HashList* hlptr, int *size) {
+    
+    *size = hlptr->size();
+    return 0;
+    
+}
+
+} // extern "C"
+

--- a/src/capi/HashList.h
+++ b/src/capi/HashList.h
@@ -1,0 +1,14 @@
+#ifndef MASH_HASH_LIST_C_H
+#define MASH_HASH_LIST_C_H
+
+#include "../mash/HashList.h"
+
+extern "C" {
+
+MASH_EXTERN_API int mash_create_hash_list(HashList* hlptr, int kmerSize);
+
+MASH_EXTERN_API int mash_hash_list_size(HashList* hlptr, int *size);
+
+} // extern "C"
+
+#endif /* ifndef MASH_HASH_LIST_C_H */

--- a/src/capi/base.h
+++ b/src/capi/base.h
@@ -1,0 +1,10 @@
+#ifndef BASE_C_H
+#define BASE_C_H
+
+// Some tools require special API declaration. Customizing the
+// MASH_EXTERN_API allows this. The default is simply nothing.
+#ifndef MASH_EXTERN_API
+#define MASH_EXTERN_API
+#endif
+
+#endif /* ifndef BASE_C_H */

--- a/src/capi/mash.h
+++ b/src/capi/mash.h
@@ -1,0 +1,7 @@
+#ifndef MASH_C_H
+#define MASH_C_H
+
+#include "base.h"
+#include "HashList.h"
+
+#endif /* ifndef MASH_C_H */


### PR DESCRIPTION
Basic es capi skeleton created to expose some functions to python:

- Libary compiling as shared library
- Base capi files created
- First function binded (from the class HashList)